### PR TITLE
Changed jsonpath plus version to 10.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "jsesc": "^3.0.2",
     "json5": "^2.2.3",
     "jsonata": "^2.0.3",
-    "jsonpath-plus": "^9.0.0",
+    "jsonpath-plus": "^10.3.0",
     "jsonwebtoken": "8.5.1",
     "jsqr": "^1.4.0",
     "jsrsasign": "^11.1.0",


### PR DESCRIPTION
Versions of the package jsonpath-plus before 10.0.7 are vulnerable to Remote Code Execution (RCE) due to improper input sanitization. An attacker can execute aribitrary code on the system by exploiting the unsafe default usage of vm in Node.

https://github.com/advisories/GHSA-pppg-cpfq-h7wr